### PR TITLE
Handle zero and traced end times in uniform_time

### DIFF
--- a/swirl_dynamics/lib/diffusion/samplers.py
+++ b/swirl_dynamics/lib/diffusion/samplers.py
@@ -163,7 +163,11 @@ def uniform_time(
     )
 
   start = diffusion.MAX_DIFFUSION_TIME
-  end = end_time or scheme.sigma.inverse(end_sigma)  # pyrefly: ignore[bad-argument-type]
+  end = (
+      end_time
+      if end_time is not None
+      else scheme.sigma.inverse(end_sigma)  # pyrefly: ignore[bad-argument-type]
+  )
   return jnp.linspace(start, end, num_steps)
 
 

--- a/swirl_dynamics/lib/diffusion/samplers_test.py
+++ b/swirl_dynamics/lib/diffusion/samplers_test.py
@@ -44,6 +44,26 @@ class TimeStepSchedulersTest(parameterized.TestCase):
       )
       np.testing.assert_allclose(tspan, np.asarray(expected), atol=1e-6)
 
+  @parameterized.product(end_time=[0.0, 0.2], compiled=[False, True])
+  def test_uniform_time_explicit_endpoint(self, end_time, compiled):
+    sigma_schedule = diffusion.tangent_noise_schedule()
+    scheme = diffusion.Diffusion.create_variance_exploding(sigma_schedule)
+    schedule = functools.partial(samplers.uniform_time, scheme, num_steps=3)
+    if compiled:
+      schedule = jax.jit(schedule)
+    tspan = schedule(end_time=jnp.asarray(end_time))
+    np.testing.assert_allclose(
+        tspan, np.linspace(1.0, end_time, 3), atol=1e-6
+    )
+
+  @parameterized.parameters((None, None), (0.0, 0.0), (0.2, 0.1))
+  def test_uniform_time_requires_one_endpoint(self, end_time, end_sigma):
+    scheme = diffusion.Diffusion.create_variance_exploding(
+        diffusion.tangent_noise_schedule()
+    )
+    with self.assertRaisesRegex(ValueError, "Exactly one"):
+      samplers.uniform_time(scheme, end_time=end_time, end_sigma=end_sigma)
+
   def test_exponential_noise_decay(self):
     num_steps = 4
     start_sigma, end_sigma = 100, 0.1


### PR DESCRIPTION
`uniform_time` uses truthiness to select its endpoint. An explicit `end_time=0.0` therefore calls the noise schedule inverse with `None`, and a JIT-traced endpoint raises `TracerBoolConversionError`.

Use an explicit `None` check. Add eager/JIT coverage for zero and positive endpoints, plus controls for the mutually exclusive endpoint arguments.

Validation: `python -m pytest -q swirl_dynamics/lib/diffusion/samplers_test.py` passes all 37 tests and two subtests. Three new regression cases fail on unchanged upstream. Syntax compilation and `git diff --check` pass.
